### PR TITLE
allow search for all fields including tags

### DIFF
--- a/src/main/java/seedu/gtd/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/gtd/logic/commands/FindCommand.java
@@ -13,7 +13,7 @@ public class FindCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks whose names contain any of "
             + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " cs2103";
     
     //@@author A0146130W
     private final String keywords;
@@ -36,10 +36,11 @@ public class FindCommand extends Command {
         model.updateFilteredTaskList(keywords, keywordSet);
         
         if(model.getFilteredTaskList().isEmpty()) {
-        	model.updateFilteredTaskList(keywordSet);
-        	if(!model.getFilteredTaskList().isEmpty()) return new CommandResult(getMessageForTaskListShownSummaryIfExactPhraseNotFound(model.getFilteredTaskList().size()));
-        }        
-        
+        	model.updateFilteredTaskList(keywords, "cmd");
+        	if(!model.getFilteredTaskList().isEmpty()) {
+        		return new CommandResult(getMessageForTaskListShownSummaryIfExactPhraseNotFound(model.getFilteredTaskList().size()));
+        	}
+        }
         return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
     }
 }

--- a/src/main/java/seedu/gtd/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/gtd/logic/commands/FindCommand.java
@@ -17,11 +17,13 @@ public class FindCommand extends Command {
     
     //@@author A0146130W
     private final String keywords;
-    private final Set<String> keywordSet;
+    private Set<String> keywordSet;
+	private final String cmd;
 
-    public FindCommand(String keywords, Set<String> keywordSet) {
+    public FindCommand(String keywords, Set<String> keywordSet, String cmd) {
         this.keywords = keywords;
         this.keywordSet = keywordSet;
+        this.cmd = cmd;
     }
     
     private String getMessageForTaskListShownSummaryIfExactPhraseNotFound(int displaySize) {
@@ -33,14 +35,26 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        model.updateFilteredTaskList(keywords, keywordSet);
-        
-        if(model.getFilteredTaskList().isEmpty()) {
-        	model.updateFilteredTaskList(keywords, "cmd");
-        	if(!model.getFilteredTaskList().isEmpty()) {
-        		return new CommandResult(getMessageForTaskListShownSummaryIfExactPhraseNotFound(model.getFilteredTaskList().size()));
-        	}
+    	System.out.println("command: " + cmd);
+    	
+    	// search by parameter if specified
+    	if (cmd != "nil") {
+    		model.updateFilteredTaskList(keywords, cmd);
+    	} else {
+    		// search by exact name
+    		model.updateFilteredTaskList(keywords, keywordSet);
+    	}
+    	if (!model.getFilteredTaskList().isEmpty()) {
+    		return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
+    	}
+    	
+    	// search by keywords
+        model.updateFilteredTaskList(keywords, "nil");
+    	
+    	if (!model.getFilteredTaskList().isEmpty()) {
+    		return new CommandResult(getMessageForTaskListShownSummaryIfExactPhraseNotFound(model.getFilteredTaskList().size()));
         }
+    	
         return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
     }
 }

--- a/src/main/java/seedu/gtd/logic/parser/Parser.java
+++ b/src/main/java/seedu/gtd/logic/parser/Parser.java
@@ -288,6 +288,36 @@ public class Parser {
      * @return the prepared command
      */
     private Command prepareFind(String args) {
+    	
+    	// check if parameters are specified and pass specified field to FindCommand
+    	
+    	String preprocessedArgs = " " + appendEnd(args.trim());
+    	final Matcher addressMatcher = ADDRESS_TASK_DATA_ARGS_FORMAT.matcher(preprocessedArgs);
+    	final Matcher priorityMatcher = PRIORITY_TASK_DATA_ARGS_FORMAT.matcher(preprocessedArgs);
+    	final Matcher dueDateMatcher = DUEDATE_TASK_DATA_ARGS_FORMAT.matcher(preprocessedArgs);
+    	final Matcher tagsMatcher = TAGS_TASK_DATA_ARGS_FORMAT.matcher(preprocessedArgs);
+    	
+    	Set<String> defaultSet = new HashSet<String>();
+    	
+    	if (addressMatcher.matches()) {
+    		String addressToBeFound = addressMatcher.group("address");
+    		return new FindCommand(addressToBeFound, defaultSet,"address");
+    	}
+    	if (priorityMatcher.matches()) {
+    		String priorityToBeFound = priorityMatcher.group("priority");
+    		return new FindCommand(priorityToBeFound, defaultSet, "priority");
+    	}
+    	if (dueDateMatcher.matches()) {
+    		String dueDateToBeFound = dueDateMatcher.group("dueDate");
+    		return new FindCommand(dueDateToBeFound, defaultSet, "dueDate");
+    	}
+    	if (tagsMatcher.matches()) {
+    		String tagsToBeFound = tagsMatcher.group("tagArguments");
+    		return new FindCommand(tagsToBeFound, defaultSet,"tagArguments");
+    	}
+    	
+    	// free-form search by keywords
+    	
         final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
         if (!matcher.matches()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -299,7 +329,7 @@ public class Parser {
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(splitKeywords));
         
         final String keywords = matcher.group("keywords");
-        return new FindCommand(keywords, keywordSet);
+        return new FindCommand(keywords, keywordSet, "nil");
     }
 
     /**

--- a/src/main/java/seedu/gtd/model/Model.java
+++ b/src/main/java/seedu/gtd/model/Model.java
@@ -39,6 +39,6 @@ public interface Model {
     /** Updates the filter of the filtered task list to filter by the given keywords*/
 	void updateFilteredTaskList(Set<String> keywordSet);
 	
-	/** Updates the filter of the filtered task list to filter by the given keywords*/
+	/** Updates the filter of the filtered task list to filter by the right parameter*/
 	void updateFilteredTaskList(String keywords, String cmd);
 }

--- a/src/main/java/seedu/gtd/model/Model.java
+++ b/src/main/java/seedu/gtd/model/Model.java
@@ -38,4 +38,7 @@ public interface Model {
     
     /** Updates the filter of the filtered task list to filter by the given keywords*/
 	void updateFilteredTaskList(Set<String> keywordSet);
+	
+	/** Updates the filter of the filtered task list to filter by the given keywords*/
+	void updateFilteredTaskList(String keywords, String cmd);
 }

--- a/src/main/java/seedu/gtd/model/ModelManager.java
+++ b/src/main/java/seedu/gtd/model/ModelManager.java
@@ -102,6 +102,11 @@ public class ModelManager extends ComponentManager implements Model {
     public void updateFilteredListToShowAll() {
         filteredTasks.setPredicate(null);
     }
+    
+    @Override
+    public void updateFilteredTaskList(Set<String> keywordSet) {
+    	updateFilteredTaskList(new PredicateExpression(new NameQualifier(keywordSet)));
+    }
 
     @Override
     public void updateFilteredTaskList(String keywords, Set<String> keywordSet){
@@ -109,13 +114,8 @@ public class ModelManager extends ComponentManager implements Model {
     }
     
     @Override
-    public void updateFilteredTaskList(Set<String> keywordSet) {
-    	updateFilteredTaskList(new PredicateExpression(new NameQualifier(keywordSet)));
-    }
-    
-    @Override
     public void updateFilteredTaskList(String keywords, String cmd) {
-    	updateFilteredTaskList(new PredicateExpression(new otherFieldsNameQualifier(keywords, cmd)));
+    	updateFilteredTaskList(new PredicateExpression(new otherFieldsQualifier(keywords, cmd)));
     }
 
     private void updateFilteredTaskList(Expression expression) {
@@ -174,15 +174,41 @@ public class ModelManager extends ComponentManager implements Model {
         }
     }
     
-    private class otherFieldsNameQualifier implements Qualifier {
+    private class otherFieldsQualifier implements Qualifier {
         protected String nameKeyWords;
+        protected String cmd;
 
-        otherFieldsNameQualifier(String keywords, String cmd) {
+        otherFieldsQualifier(String keywords, String cmd) {
             this.nameKeyWords = keywords;
+            this.cmd = cmd;
         }
 
         @Override
         public boolean run(ReadOnlyTask task) {
+        	if (cmd == "address") {
+        		System.out.println("finding address..");
+        		String address = task.getAddress().toString().toLowerCase();
+        		boolean addressMatch = address.contains(nameKeyWords.toLowerCase());
+        		return addressMatch;
+        	} else if (cmd == "priority") {
+        		System.out.println("finding priority..");
+        		String priority = task.getPriority().toString();
+        		boolean priorityMatch = priority.contains(nameKeyWords);
+        		return priorityMatch;
+        	} else if (cmd == "dueDate") {
+        		System.out.println("finding dueDate..");
+        		String dueDate = task.getDueDate().toString();
+        		boolean dueDateMatch = dueDate.contains(nameKeyWords);
+        		return dueDateMatch;
+        	} else if (cmd == "tagArguments") {
+        		System.out.println("finding tags.. ");
+        		UniqueTagList tagsList = task.getTags();
+        		boolean tagsMatch = tagsList.containSearch(nameKeyWords.toLowerCase());
+        		return tagsMatch;
+        	}
+        	
+        	// cmd == "nil"
+        	
         	String taskFullNameLowerCase = task.getName().fullName.toLowerCase();
         	String priority = task.getPriority().toString();
         	String address = task.getAddress().toString().toLowerCase();

--- a/src/main/java/seedu/gtd/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/gtd/model/tag/UniqueTagList.java
@@ -3,6 +3,7 @@ package seedu.gtd.model.tag;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.gtd.commons.exceptions.DuplicateDataException;
+import seedu.gtd.commons.exceptions.IllegalValueException;
 import seedu.gtd.commons.util.CollectionUtil;
 
 import java.util.*;
@@ -104,6 +105,25 @@ public class UniqueTagList implements Iterable<Tag> {
     public boolean contains(Tag toCheck) {
         assert toCheck != null;
         return internalList.contains(toCheck);
+    }
+    
+    
+    
+    public boolean containSearch(String toCheck) {
+        assert toCheck != null;
+        boolean containsTag = true;
+        try {
+        	String[] tagsArray = toCheck.split(" ");
+        	
+        	for (String tag : tagsArray) {
+        		System.out.println(tag);
+        		Tag searchTag = new Tag(tag);
+        		containsTag = containsTag && internalList.contains(searchTag);
+        	}
+        	return containsTag;
+		} catch (IllegalValueException e) {
+			return false;
+		}
     }
 
     /**


### PR DESCRIPTION
A little hacky because I created another overloading method to allow
for comparisons of other fields without disrupting the current methods
and qualifiers. Do let me know if there are better ways to do this! The "cmd" parameter can actually be useful for better filters. ie Instead of "find 1", "cmd" can be "priority" as in "find priority 1".